### PR TITLE
[#7] Add validation for request body fields and endpoint parameters

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -68,6 +68,11 @@
 			<artifactId>spring-boot-starter-test</artifactId>
 			<scope>test</scope>
 		</dependency>
+
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-validation</artifactId>
+		</dependency>
 	</dependencies>
 	<dependencyManagement>
 		<dependencies>

--- a/src/main/java/com/david/savetodouserservice/User/CreateUserRequest.java
+++ b/src/main/java/com/david/savetodouserservice/User/CreateUserRequest.java
@@ -1,8 +1,25 @@
 package com.david.savetodouserservice.User;
 
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
+
 public record CreateUserRequest(
+
+        @NotBlank(message = "Name is required")
+        @Size(min = 2, max = 50, message = "Name must have between 2 and 50 characters")
         String name,
+
+        @NotBlank(message = "Email is required")
+        @Email(message = "Invalid email format")
         String email,
+
+        @Size(min = 8, max = 64, message = "Password must contain between 8 and 64 characters")
+        @Pattern(
+                regexp = "^(?=.*[a-z])(?=.*[A-Z])(?=.*\\d)(?=.*[@$!%*?&])[A-Za-z\\d@$!%*?&]{8,64}$",
+                message = "Password must include uppercase, lowercase, number, special character (@$!%*?&), and contain no spaces"
+        )
         String password
 ) {
 }

--- a/src/main/java/com/david/savetodouserservice/User/GlobalExceptionHandler.java
+++ b/src/main/java/com/david/savetodouserservice/User/GlobalExceptionHandler.java
@@ -1,12 +1,15 @@
 package com.david.savetodouserservice.User;
 
+import jakarta.validation.ConstraintViolationException;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 import org.springframework.web.context.request.WebRequest;
 
 import java.time.LocalDateTime;
+import java.util.*;
 
 @RestControllerAdvice
 public class GlobalExceptionHandler {
@@ -48,6 +51,37 @@ public class GlobalExceptionHandler {
         );
 
         return new ResponseEntity<>(errorResponseDto, HttpStatus.INTERNAL_SERVER_ERROR);
+    }
+
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<ValidationErrorResponseDto> handleMethodArgumentNotValidException(MethodArgumentNotValidException ex,
+                                                                                            WebRequest webRequest) {
+        Map<String, Set<String>> errors = new HashMap<>();
+        ex.getFieldErrors().forEach(error -> errors.computeIfAbsent(error.getField(), key -> new HashSet<>())
+                                                   .add(error.getDefaultMessage())
+        );
+
+        ValidationErrorResponseDto errorResponseDto = new ValidationErrorResponseDto(
+                webRequest.getDescription(false),
+                HttpStatus.BAD_REQUEST,
+                errors,
+                LocalDateTime.now()
+        );
+
+        return new ResponseEntity<>(errorResponseDto, HttpStatus.BAD_REQUEST);
+    }
+
+    @ExceptionHandler(ConstraintViolationException.class)
+    public ResponseEntity<ErrorResponseDto> handleConstraintViolationException(ConstraintViolationException ex,
+                                                                               WebRequest webRequest) {
+        ErrorResponseDto errorResponseDto = new ErrorResponseDto(
+                webRequest.getDescription(false),
+                HttpStatus.BAD_REQUEST,
+                ex.getMessage(),
+                LocalDateTime.now()
+        );
+
+        return new ResponseEntity<>(errorResponseDto, HttpStatus.BAD_REQUEST);
     }
 
 }

--- a/src/main/java/com/david/savetodouserservice/User/UpdateUserRequest.java
+++ b/src/main/java/com/david/savetodouserservice/User/UpdateUserRequest.java
@@ -1,6 +1,12 @@
 package com.david.savetodouserservice.User;
 
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
 public record UpdateUserRequest(
+
+        @NotBlank(message = "Name is required")
+        @Size(min = 2, max = 50, message = "Name must have between 2 and 50 characters")
         String name
 ) {
 }

--- a/src/main/java/com/david/savetodouserservice/User/UserController.java
+++ b/src/main/java/com/david/savetodouserservice/User/UserController.java
@@ -1,6 +1,9 @@
 package com.david.savetodouserservice.User;
 
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.Min;
 import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
 
@@ -8,7 +11,8 @@ import java.net.URI;
 import java.util.List;
 
 @RestController
-@RequestMapping("api/users")
+@RequestMapping("/api/users")
+@Validated
 public class UserController {
 
     private final UserService userService;
@@ -18,7 +22,7 @@ public class UserController {
     }
 
     @PostMapping
-    public ResponseEntity<UserResponse> createUser(@RequestBody CreateUserRequest userRequest) {
+    public ResponseEntity<UserResponse> createUser(@Valid @RequestBody CreateUserRequest userRequest) {
         UserResponse createdUser = userService.createUser(userRequest);
 
         URI location = ServletUriComponentsBuilder
@@ -38,20 +42,20 @@ public class UserController {
                 .ok(userService.findAllUsers());
     }
 
-    @GetMapping("{id}")
-    public ResponseEntity<UserResponse> getUser(@PathVariable Long id) {
+    @GetMapping("/{id}")
+    public ResponseEntity<UserResponse> getUser(@Min(1) @PathVariable Long id) {
         return ResponseEntity
                 .ok(userService.findUserById(id));
     }
 
-    @PutMapping("{id}")
-    public ResponseEntity<UserResponse> updateUser(@PathVariable Long id, @RequestBody UpdateUserRequest userRequest) {
+    @PutMapping("/{id}")
+    public ResponseEntity<UserResponse> updateUser(@Min(1) @PathVariable Long id, @Valid @RequestBody UpdateUserRequest userRequest) {
         return ResponseEntity
                 .ok(userService.updateUser(id, userRequest));
     }
 
     @DeleteMapping("/{id}")
-    public ResponseEntity<Void> deleteUser(@PathVariable Long id) {
+    public ResponseEntity<Void> deleteUser(@Min(1) @PathVariable Long id) {
         userService.deleteUser(id);
         return ResponseEntity.noContent().build();
     }

--- a/src/main/java/com/david/savetodouserservice/User/ValidationErrorResponseDto.java
+++ b/src/main/java/com/david/savetodouserservice/User/ValidationErrorResponseDto.java
@@ -1,0 +1,15 @@
+package com.david.savetodouserservice.User;
+
+import org.springframework.http.HttpStatus;
+
+import java.time.LocalDateTime;
+import java.util.Map;
+import java.util.Set;
+
+public record ValidationErrorResponseDto(
+        String apiPath,
+        HttpStatus errorCode,
+        Map<String, Set<String>> fieldsErrors,
+        LocalDateTime timestamp
+) {
+}


### PR DESCRIPTION
### ✅ What does this PR do?
This PR adds validation for request body fields and endpoints (path) parameters

---

### 📋 Related Issue(s)
Closes #7

---

### 🛠 Changes made
- Added Jakarta validation dependency
- Added validation constraints to DTO fields
- Added validation constraints to endpoint parameters
- Created custom error response DTO for request body validation errors
- Implemented exception handlers for MethodArgumentNotValidException and ConstraintViolationException
- Explicitly added starting "/" to all endpoint paths

---

### 📸 Screenshots (if applicable)
*N/A for this PR*

---

### 🔎 How to test
1. Run Eureka Server (localhost:8761)
2. Start user-service
3. Open Postman
4. Test endpoints with both valid and invalid payloads, including scenarios where id is 0:
    - POST /api/users to create a user
    - GET /api/users/{id} to fetch a user
    - PUT /api/users/{id} to update a user
    - DELETE /api/users/{id} to delete a user

---

### 🧠 Notes
- Further validation can be explored in future PRs, if needed